### PR TITLE
Add spacing to Intro elements

### DIFF
--- a/assets/css/patterns/intro-with-links.css
+++ b/assets/css/patterns/intro-with-links.css
@@ -6,7 +6,7 @@
 }
 
 .intro-with-links-columns {
-    gap: var(--wp--preset--spacing--50);
+    justify-content: space-between;
 }
 
 /* Initial Animation States */


### PR DESCRIPTION
## 📝 Add spacing to Intro elements

## 📌 Summary
The introduction and links were too narrow on the desktop so this PR includes a `space-between` flexbox rule to add that necessary spacing allowing the section to take up the content width.

## 🔍 Changes Made
- [x] **Style:** Add `justify-content: space-between;`

## 🛠️ Testing & Verification
- [x] Code was run locally and verified

## ✅ Checklist
- [x] My code follows the established coding standards  
- [x] Code is self-documented or properly commented  
- [x] No console errors or warnings  
- [x] No unnecessary files, console logs, or commented-out code 
